### PR TITLE
ニコニコ対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ dist_package/
 *.zip
 *.exe
 
+# User data (cookies, etc.)
+/data/
+
 # OS generated files
 .DS_Store
 .DS_Store?

--- a/gui.py
+++ b/gui.py
@@ -141,6 +141,9 @@ def get_optimal_format_string():
     """環境に応じた最適なフォーマット文字列を生成"""
     av1_supported, av1_decoders = check_av1_support()
     
+    # 720p未満の古い動画も再生できるよう、'bestvideo+bestaudio/best'をフォールバックとして追加
+    fallback_formats = 'bestvideo+bestaudio/best'
+
     if av1_supported:
         # AV1対応環境: パフォーマンスを考慮して2160p以下に制限
         format_str = (
@@ -148,7 +151,7 @@ def get_optimal_format_string():
             'bestvideo[vcodec!*=av01][height<=1440][height>=720]+bestaudio/'  # AV1が重い場合のフォールバック
             'best[height<=2160][height>=720]/'
             'bestvideo[height>=720]+bestaudio/'
-            'best'
+            f'{fallback_formats}' # 低解像度動画用のフォールバック
         )
         codec_info = f"AV1対応 (デコーダー: {', '.join(av1_decoders)}, 2160p以下)"
     else:
@@ -158,7 +161,7 @@ def get_optimal_format_string():
             'bestvideo[vcodec!*=av01][height>=720]+bestaudio/'
             'best[vcodec!*=av01][height>=720]/'
             'bestvideo[height>=720]+bestaudio/'
-            'best'
+            f'{fallback_formats}' # 低解像度動画用のフォールバック
         )
         codec_info = "AV1非対応 (H.264/VP9を優先, 2160p以下)"
     

--- a/gui.py
+++ b/gui.py
@@ -165,12 +165,16 @@ def get_optimal_format_string():
     return format_str, codec_info
 
 def build_ffmpeg_header_args(headers: dict) -> list:
-    args = []
+    """ffmpegに渡すHTTPヘッダーを構築する。-headersオプションは単一の文字列を要求する。"""
     if not headers:
-        return args
-    for k, v in headers.items():
-        args += ["-headers", f"{k}: {v}"]
-    return args
+        return []
+    
+    # ヘッダーを `Key: Value` の形式でリスト化し、CRLFで結合する
+    # 注: yt-dlpが返すhttp_headersにはCookieが含まれている想定
+    header_lines = [f"{k}: {v}" for k, v in headers.items()]
+    header_string = "\r\n".join(header_lines) + "\r\n"
+    
+    return ["-headers", header_string]
 
 
 def detect_fps(info: dict) -> int | None:
@@ -254,9 +258,14 @@ class Streamer:
             pass
 
     def _yt_refresh(self) -> bool:
+        # dataディレクトリを作成（存在しない場合）
+        os.makedirs("data", exist_ok=True)
+        cookie_file = os.path.join("data", "cookies.txt")
+
         # 環境に応じた最適なフォーマット文字列を取得
         format_str, codec_info = get_optimal_format_string()
         self.log(f"コーデック対応状況: {codec_info}")
+        self.log(f"Cookieファイルとして'{cookie_file}'を使用します。")
         
         # カスタムログハンドラーを作成
         class YtDlpLogger:
@@ -290,6 +299,8 @@ class Streamer:
             'retries': 3,
             # User-Agentを設定してブロック回避
             'user_agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            # Cookieファイルを強制的に指定
+            'cookiefile': cookie_file,
         }
         
         # certifiパッケージが利用可能な場合は使用
@@ -316,6 +327,7 @@ class Streamer:
         # URL は info.url を優先し、無ければ requested_formats の video 側から取得
         self.stream_url = info.get("url")
         self.http_headers = info.get("http_headers", {})
+
         if not self.stream_url:
             rf = info.get("requested_formats")
             if isinstance(rf, list):
@@ -325,6 +337,33 @@ class Streamer:
                         self.http_headers = f.get(
                             "http_headers", {}) or self.http_headers
                         break
+
+        # --- Cookieヘッダーの手動挿入 ---
+        # yt-dlpがhttp_headersにCookieを含めない問題への対策
+        try:
+            import http.cookiejar
+            import urllib.parse
+
+            cj = http.cookiejar.MozillaCookieJar(cookie_file)
+            cj.load(ignore_discard=True, ignore_expires=True)
+
+            if self.stream_url:
+                parsed_url = urllib.parse.urlparse(self.stream_url)
+                domain = parsed_url.netloc
+                
+                cookie_dict = {}
+                for cookie in cj:
+                    if cookie.domain and domain.endswith(cookie.domain):
+                        cookie_dict[cookie.name] = cookie.value
+                
+                if cookie_dict:
+                    cookie_header_val = "; ".join([f"{k}={v}" for k, v in cookie_dict.items()])
+                    self.http_headers['Cookie'] = cookie_header_val
+                    self.log("Cookieを手動で解析し、ffmpegヘッダーに追加しました。")
+        except Exception as e:
+            self.log(f"Cookieファイルの手動解析に失敗: {e}")
+        # --- 手動挿入ここまで ---
+
         self.is_live = bool(info.get("is_live"))
         fps = detect_fps(info)
         if fps:

--- a/main.py
+++ b/main.py
@@ -99,6 +99,9 @@ def get_optimal_format_string():
     """環境に応じた最適なフォーマット文字列を生成"""
     av1_supported, av1_decoders = check_av1_support()
     
+    # 720p未満の古い動画も再生できるよう、'bestvideo+bestaudio/best'をフォールバックとして追加
+    fallback_formats = 'bestvideo+bestaudio/best'
+
     if av1_supported:
         # AV1対応環境: パフォーマンスを考慮して2160p以下に制限
         format_str = (
@@ -106,7 +109,7 @@ def get_optimal_format_string():
             'bestvideo[vcodec!*=av01][height<=1440][height>=720]+bestaudio/'  # AV1が重い場合のフォールバック
             'best[height<=2160][height>=720]/'
             'bestvideo[height>=720]+bestaudio/'
-            'best'
+            f'{fallback_formats}' # 低解像度動画用のフォールバック
         )
         codec_info = f"AV1対応 (デコーダー: {', '.join(av1_decoders)}, 2160p以下)"
     else:
@@ -116,7 +119,7 @@ def get_optimal_format_string():
             'bestvideo[vcodec!*=av01][height>=720]+bestaudio/'
             'best[vcodec!*=av01][height>=720]/'
             'bestvideo[height>=720]+bestaudio/'
-            'best'
+            f'{fallback_formats}' # 低解像度動画用のフォールバック
         )
         codec_info = "AV1非対応 (H.264/VP9を優先, 2160p以下)"
     

--- a/main.py
+++ b/main.py
@@ -124,12 +124,16 @@ def get_optimal_format_string():
 
 
 def build_ffmpeg_header_args(headers: dict) -> list:
-    args = []
+    """ffmpegに渡すHTTPヘッダーを構築する。-headersオプションは単一の文字列を要求する。"""
     if not headers:
-        return args
-    for k, v in headers.items():
-        args += ["-headers", f"{k}: {v}"]
-    return args
+        return []
+    
+    # ヘッダーを `Key: Value` の形式でリスト化し、CRLFで結合する
+    # 注: yt-dlpが返すhttp_headersにはCookieが含まれている想定
+    header_lines = [f"{k}: {v}" for k, v in headers.items()]
+    header_string = "\r\n".join(header_lines) + "\r\n"
+    
+    return ["-headers", header_string]
 
 
 def detect_fps(info: dict) -> Optional[int]:
@@ -209,11 +213,16 @@ class CLIStreamer:
 
     def _yt_refresh(self) -> bool:
         """yt-dlpでストリーム情報を取得・更新"""
+        # dataディレクトリを作成（存在しない場合）
+        os.makedirs("data", exist_ok=True)
+        cookie_file = os.path.join("data", "cookies.txt")
+
         # 環境に応じた最適なフォーマット文字列を取得
         format_str, codec_info = get_optimal_format_string()
         if self.verbose:
             self.log(f"コーデック対応状況: {codec_info}")
-        
+            self.log(f"Cookieファイルとして'{cookie_file}'を使用します。")
+
         ydl_opts = {
             # 環境に応じて動的に決定されたフォーマット
             'format': format_str,
@@ -226,6 +235,8 @@ class CLIStreamer:
             'retries': 3,
             # User-Agentを設定してブロック回避
             'user_agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            # Cookieファイルを強制的に指定
+            'cookiefile': cookie_file,
         }
         
         # certifiパッケージが利用可能な場合は使用
@@ -253,6 +264,7 @@ class CLIStreamer:
         # URL取得
         self.stream_url = info.get("url")
         self.http_headers = info.get("http_headers", {})
+        
         if not self.stream_url:
             rf = info.get("requested_formats")
             if isinstance(rf, list):
@@ -261,6 +273,34 @@ class CLIStreamer:
                         self.stream_url = f.get("url")
                         self.http_headers = f.get("http_headers", {}) or self.http_headers
                         break
+
+        # --- Cookieヘッダーの手動挿入 ---
+        # yt-dlpがhttp_headersにCookieを含めない問題への対策
+        try:
+            import http.cookiejar
+            import urllib.parse
+
+            cj = http.cookiejar.MozillaCookieJar(cookie_file)
+            cj.load(ignore_discard=True, ignore_expires=True)
+
+            if self.stream_url:
+                parsed_url = urllib.parse.urlparse(self.stream_url)
+                domain = parsed_url.netloc
+                
+                cookie_dict = {}
+                for cookie in cj:
+                    if cookie.domain and domain.endswith(cookie.domain):
+                        cookie_dict[cookie.name] = cookie.value
+                
+                if cookie_dict:
+                    cookie_header_val = "; ".join([f"{k}={v}" for k, v in cookie_dict.items()])
+                    self.http_headers['Cookie'] = cookie_header_val
+                    if self.verbose:
+                        self.log("Cookieを手動で解析し、ffmpegヘッダーに追加しました。")
+        except Exception as e:
+            if self.verbose:
+                self.log(f"Cookieファイルの手動解析に失敗: {e}")
+        # --- 手動挿入ここまで ---
 
         self.is_live = bool(info.get("is_live"))
         


### PR DESCRIPTION
ニコニコ動画が再生できない問題を、以下の二点を修正することで解決

- cookieを使用して動画を読み込む
- 低解像度のみの動画にも対応